### PR TITLE
Correction of an installation error in a future version of zpm

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="remote-server-control.ZPM">
     <Module>
       <Name>remote-server-control</Name>
-      <Version>1.0.3</Version>
+      <Version>1.0.4</Version>
       <Description>Simple remote server control</Description>
       <Keywords>TCP, System Mgmt</Keywords>
       <Packaging>module</Packaging>

--- a/src/Zrcc/remote.cls
+++ b/src/Zrcc/remote.cls
@@ -102,5 +102,27 @@ reset
    use 0 write reply,! 
    goto reset
 }
+
+Storage Default
+{
+<Data name="remoteDefaultData">
+<Value name="1">
+<Value>Server</Value>
+</Value>
+<Value name="2">
+<Value>IPaddr</Value>
+</Value>
+<Value name="3">
+<Value>Listener</Value>
+</Value>
+</Data>
+<DataLocation>^Zrcc.remoteD</DataLocation>
+<DefaultData>remoteDefaultData</DefaultData>
+<IdLocation>^Zrcc.remoteD</IdLocation>
+<IndexLocation>^Zrcc.remoteI</IndexLocation>
+<StreamLocation>^Zrcc.remoteS</StreamLocation>
+<Type>%Storage.Persistent</Type>
+}
+
 }
 


### PR DESCRIPTION
This module has a persistent class without any specific storage and this is stated in the error.
The author must define the Storage and publish the new version. The new version of the zpm will have an installation error.
 Update the release in Open Exchange please.
https://openexchange.intersystems.com/markdown?url=assets%2Fdoc%2Freleases.md
Thanks.

%SYS>ver
%SYS> zpm 0.2.15-dev.228.5
zapm:USER>install remote-server-control
 
[remote-server-control] Reload START (D:\InterSystems\IRISPY\mgr\.modules\USER\remote-server-control\1.0.3\)
[remote-server-control] Reload SUCCESS
[remote-server-control] Module object refreshed.
[remote-server-control] Validate START
[remote-server-control] Validate SUCCESS
[remote-server-control] Compile START
[remote-server-control] Compile FAILURE
ERROR! Storage on class Zrcc.remote modified by storage compiler, developer should have run ^build to make sure all storage is updated correctly and saved to Perforce